### PR TITLE
Allow running as any other user

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,7 @@ versions:
   rex:     0.2.2b1.0.6
   process_exporter: 0.4.0
 
+restund_user: restund
 restund_udp_listen_port: 3478
 restund_tcp_listen_port: 3478
 restund_tls_listen_port: 5349

--- a/tasks/restund.yml
+++ b/tasks/restund.yml
@@ -1,14 +1,14 @@
 ---
 - name: add {{ restund_user }} group
-  group: name={{ restund_user }} state=present system=true
+  group: name="{{ restund_user }}" state=present system=true
   tags:
     - restund
 
 - name: add {{ restund_user }} user
   user:
-    name:   {{ restund_user }}
+    name:   "{{ restund_user }}"
     shell:  /bin/false
-    group:  {{ restund_user }}
+    group:  "{{ restund_user }}"
     system: true
     createhome: false
   tags:

--- a/tasks/restund.yml
+++ b/tasks/restund.yml
@@ -19,8 +19,8 @@
     path:  /etc/restund
     state: directory
     mode:  0755
-    owner: {{ restund_user }}
-    group: {{ restund_user }}
+    owner: "{{ restund_user }}"
+    group: "{{ restund_user }}"
   tags:
     - restund
 
@@ -29,8 +29,8 @@
     src:   templates/restund.conf.j2
     dest:  /etc/restund/restund.conf
     mode:  0440
-    owner: {{ restund_user }}
-    group: {{ restund_user }}
+    owner: "{{ restund_user }}"
+    group: "{{ restund_user }}"
   tags:
     - restund
 

--- a/tasks/restund.yml
+++ b/tasks/restund.yml
@@ -1,14 +1,14 @@
 ---
-- name: add restund group
-  group: name=restund state=present system=true
+- name: add {{ restund_user }} group
+  group: name={{ restund_user }} state=present system=true
   tags:
     - restund
 
-- name: add restund user
+- name: add {{ restund_user }} user
   user:
-    name:   restund
+    name:   {{ restund_user }}
     shell:  /bin/false
-    group:  restund
+    group:  {{ restund_user }}
     system: true
     createhome: false
   tags:
@@ -19,8 +19,8 @@
     path:  /etc/restund
     state: directory
     mode:  0755
-    owner: restund
-    group: restund
+    owner: {{ restund_user }}
+    group: {{ restund_user }}
   tags:
     - restund
 
@@ -29,8 +29,8 @@
     src:   templates/restund.conf.j2
     dest:  /etc/restund/restund.conf
     mode:  0440
-    owner: restund
-    group: restund
+    owner: {{ restund_user }}
+    group: {{ restund_user }}
   tags:
     - restund
 

--- a/templates/restund.service.j2
+++ b/templates/restund.service.j2
@@ -14,8 +14,8 @@ ExecStart=/usr/bin/rkt run \
     --hosts-entry=host \
     --volume volume-usr-local-etc-restund,kind=host,source=/etc/restund,readOnly=true \
     {{ aci_base_url }}/restund/restund-{{ versions.restund }}_linux_amd64.aci \
-    --user=restund \
-    --group=restund
+    --user={{ restund_user }} \
+    --group={{ restund_user }}
 ExecStopPost=/usr/bin/rkt gc --mark-only
 KillMode=mixed
 Restart=always


### PR DESCRIPTION
This is particularly useful if you want to run it as root (`rkt` is anyway called with root privileges) to listen on privileged ports.