### PR TITLE
Allow tls

### DIFF
--- a/examples/restund.yml
+++ b/examples/restund.yml
@@ -13,7 +13,22 @@
   gather_facts: no
   become: no
   tasks:
-    - set_fact:
+    # Uncomment this if you want to use TLS
+    # - name: Read TLS config
+    #   set_fact:
+    #     # Reminder that the pem file should look like:
+    #     # -----BEGIN CERTIFICATE-----
+    #     # --- ... CERT CONTENT ... --
+    #     # -----END CERTIFICATE-----
+    #     # -----BEGIN CERTIFICATE-----
+    #     # --- ... INTERMEDIATE ..----
+    #     # -----END CERTIFICATE----
+    #     # -----BEGIN PRIVATE KEY-----
+    #     # --- .... PRIV KEY -----
+    #     # -----END PRIVATE KEY-----
+    #     restund_tls_certificate: "{{ lookup('file', '/tmp/tls_cert_and_priv_key.pem') }}"
+    - name: Get TURN secret
+      set_fact:
         # NOTE: Ensure that the zrest secret is the same as used by brig!
         restund_zrest_secret: 'ENSURE_YOU_DEFINE_THIS_WITH_THE_SAME_VALUE_AS_BRIG'
   tags:
@@ -35,7 +50,8 @@
   become: yes
   any_errors_fatal: True
   vars:
-    # TODO: Add TLS certificate
+    # Uncomment if you want to use TLS
+    # restund_tls_certificate: '{{ hostvars.localhost.restund_zrest_secret }}'
     restund_zrest_secret: '{{ hostvars.localhost.restund_zrest_secret }}'
   roles:
     - hostname

--- a/tasks/restund.yml
+++ b/tasks/restund.yml
@@ -24,16 +24,6 @@
   tags:
     - restund
 
-- name: restund.conf
-  template:
-    src:   templates/restund.conf.j2
-    dest:  /etc/restund/restund.conf
-    mode:  0440
-    owner: "{{ restund_user }}"
-    group: "{{ restund_user }}"
-  tags:
-    - restund
-
 - name: install restund tls certificate
   copy:
     dest:    /etc/restund/restund.pem
@@ -42,6 +32,16 @@
     owner:   "{{ restund_user }}"
     group:   "{{ restund_user }}"
   when: restund_tls_certificate is defined
+  tags:
+    - restund
+
+- name: restund.conf
+  template:
+    src:   templates/restund.conf.j2
+    dest:  /etc/restund/restund.conf
+    mode:  0440
+    owner: "{{ restund_user }}"
+    group: "{{ restund_user }}"
   tags:
     - restund
 

--- a/tasks/restund.yml
+++ b/tasks/restund.yml
@@ -34,16 +34,16 @@
   tags:
     - restund
 
-# TODO: Ensure we install the tls certificate
-# - name: install restund tls certificate
-#   copy:
-#     dest:    /etc/restund/restund.pem
-#     content: '{{ restund_tls_certificate }}'
-#     mode:    0440
-#     owner:   restund
-#     group:   restund
-#   tags:
-#     - restund
+- name: install restund tls certificate
+  copy:
+    dest:    /etc/restund/restund.pem
+    content: "{{ restund_tls_certificate }}"
+    mode:    0440
+    owner:   "{{ restund_user }}"
+    group:   "{{ restund_user }}"
+  when: restund_tls_certificate is defined
+  tags:
+    - restund
 
 - name: install restund unit file
   template:

--- a/templates/restund.conf.j2
+++ b/templates/restund.conf.j2
@@ -6,7 +6,7 @@ syncinterval            600
 udp_listen              {{ hostvars[inventory_hostname]['ansible_' + restund_network_interface].ipv4.address }}:{{ restund_udp_listen_port }}
 udp_sockbuf_size        524288
 tcp_listen              {{ hostvars[inventory_hostname]['ansible_' + restund_network_interface].ipv4.address }}:{{ restund_tcp_listen_port }}
-{% if restund_tls_certificate %}
+{% if restund_tls_certificate is defined %}
 tls_listen              {{ hostvars[inventory_hostname]['ansible_' + restund_network_interface].ipv4.address }}:{{ restund_tls_listen_port }},/usr/local/etc/restund/restund.pem
 {% endif %}
 

--- a/templates/restund.conf.j2
+++ b/templates/restund.conf.j2
@@ -6,8 +6,9 @@ syncinterval            600
 udp_listen              {{ hostvars[inventory_hostname]['ansible_' + restund_network_interface].ipv4.address }}:{{ restund_udp_listen_port }}
 udp_sockbuf_size        524288
 tcp_listen              {{ hostvars[inventory_hostname]['ansible_' + restund_network_interface].ipv4.address }}:{{ restund_tcp_listen_port }}
-# TODO: Readd TLS
-# tls_listen              {{ hostvars[inventory_hostname]['ansible_' + restund_network_interface].ipv4.address }}:{{ restund_tls_listen_port }},/usr/local/etc/restund/restund.pem
+{% if restund_tls_certificate %}
+tls_listen              {{ hostvars[inventory_hostname]['ansible_' + restund_network_interface].ipv4.address }}:{{ restund_tls_listen_port }},/usr/local/etc/restund/restund.pem
+{% endif %}
 
 # modules
 module_path             /usr/local/lib/restund/modules


### PR DESCRIPTION
When a TLS certificate is provided (e.g., like [this](https://github.com/wireapp/wire-server-deploy/blob/ansible-restund-example-root-and-tls/ansible/restund.yml)), then restund will also listen on the `restund_tls_listen_port` for incoming TLS connections.