### PR TITLE
Do not restrict login shell for the restund user

### DIFF
--- a/tasks/restund.yml
+++ b/tasks/restund.yml
@@ -1,15 +1,21 @@
 ---
 - name: add {{ restund_user }} group
-  group: name="{{ restund_user }}" state=present system=true
+  group:
+    name: "{{ restund_user }}"
+    state: present
+    system: true
   tags:
     - restund
+  when: restund_user != 'root'
 
 - name: add {{ restund_user }} user
   user:
-    name:   "{{ restund_user }}"
-    group:  "{{ restund_user }}"
+    name: "{{ restund_user }}"
+    shell: "/bin/false"
+    group: "{{ restund_user }}"
     system: true
     createhome: false
+  when: restund_user != 'root'
   tags:
     - restund
 

--- a/tasks/restund.yml
+++ b/tasks/restund.yml
@@ -7,7 +7,6 @@
 - name: add {{ restund_user }} user
   user:
     name:   "{{ restund_user }}"
-    shell:  /bin/false
     group:  "{{ restund_user }}"
     system: true
     createhome: false


### PR DESCRIPTION
Setting the shell to `/bin/false` can have _interesting_ effects. What happened: I was provisioning restund to run as the user root. Well, the only user able to ssh into the machine was root itself so I basically locked myself out.

So we can either do what I am suggesting here (leaving the default, OS dependent shell - generally `/bin/bash`) or we could use `/bin/false` iff `restund_user != ansible_user`