### PR TITLE
Support metrics at nginx level

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,7 @@ restund_tcp_listen_port: 3478
 restund_tls_listen_port: 5349
 restund_udp_status_port: 33000
 restund_http_status_port: 8080
+restund_metrics_listen_port: 8443
 
 restund_network_interface: "{% if ansible_default_ipv4 is defined %}{{ ansible_default_ipv4.interface }}{% else %}eth0{% endif %}"
 
@@ -29,3 +30,8 @@ certbot_enable_checks: true
 nginx_worker_connections: 65536
 nginx_rlimit_nofile: "{{ nginx_worker_connections * 2 }}"
 nginx_localhost_config_dir: /tmp/conf
+
+restund_metrics_enabled: true
+# FUTUREWORK: currently you need to provide your own client certificate CA file
+# before using this role if setting this to true.
+restund_metrics_clientcertificates_enabled: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,7 @@ certbot_admin_email: # e.g. example@example.com
 certbot_domain: # e.g. restund01.example.com
 # set to false if DNS records point indirectly to this machine (e.g. when using load balancers)
 certbot_enable_checks: true
+certbot_webroot_directory: /usr/share/nginx/html
 nginx_worker_connections: 65536
 nginx_rlimit_nofile: "{{ nginx_worker_connections * 2 }}"
 nginx_localhost_config_dir: /tmp/conf

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,7 +31,14 @@ nginx_worker_connections: 65536
 nginx_rlimit_nofile: "{{ nginx_worker_connections * 2 }}"
 nginx_localhost_config_dir: /tmp/conf
 
-restund_metrics_enabled: true
-# FUTUREWORK: currently you need to provide your own client certificate CA file
+# NOTE: currently you need to install your own exporters,
+# setting this to true will only add an nginx block forwarding traffic
+# to local exporters if they exist (but this role currently doesn't install any).
+# FUTUREWORK: install exporters as part of this role
+restund_metrics_enabled: false
+
+# NOTE: currently you need to provide your own client certificate CA file
 # before using this role if setting this to true.
-restund_metrics_clientcertificates_enabled: false
+# FUTUREWORK: ease the process of using client certificates,
+# and only enable the client cert block if a CA cert is present.
+restund_metrics_client_certificates_enabled: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,7 +30,7 @@ certbot_enable_checks: true
 certbot_webroot_directory: /usr/share/nginx/html
 nginx_worker_connections: 65536
 nginx_rlimit_nofile: "{{ nginx_worker_connections * 2 }}"
-nginx_localhost_config_dir: /tmp/conf
+nginx_localhost_config_dir: "/tmp/conf/{{ certbot_domain }}"
 
 # NOTE: currently you need to install your own exporters,
 # setting this to true will only add an nginx block forwarding traffic

--- a/tasks/certbot_nginx.yml
+++ b/tasks/certbot_nginx.yml
@@ -130,6 +130,7 @@
   with_items:
     - { src: nginx.conf.j2, dest: "{{ nginx_localhost_config_dir }}/nginx.conf" }
     - { src: nginx-default.conf.j2, dest: "{{ nginx_localhost_config_dir }}/http/default.conf" }
+    - { src: nginx-metrics.conf.j2, dest: "{{ nginx_localhost_config_dir }}/http/metrics.conf" }
     - { src: nginx-stream.conf.j2, dest: "{{ nginx_localhost_config_dir }}/stream/restund.conf" }
   delegate_to: localhost
   become: false

--- a/tasks/certbot_nginx.yml
+++ b/tasks/certbot_nginx.yml
@@ -82,6 +82,11 @@
     src: nginx.service.override.j2
     dest: /etc/systemd/system/nginx.service.d/override.conf
 
+- name: create dir for .well-known file
+  file:
+    path: "{{ certbot_webroot_directory }}"
+    state: directory
+
 - name: check which packages are installed
   package_facts:
 
@@ -106,7 +111,7 @@
   register: cert_file
 
 - name: create certificates with cerbot/letsencrypt (this also installs a renewal cron job)
-  shell: 'certbot certonly --webroot -w /var/www/html -n --agree-tos --email {{ certbot_admin_email }} -d {{ certbot_domain }}'
+  shell: 'certbot certonly --webroot --webroot-path {{ certbot_webroot_directory }} -n --agree-tos --email {{ certbot_admin_email }} -d {{ certbot_domain }}'
   when: not cert_file.stat.exists
 
 

--- a/tasks/restund.yml
+++ b/tasks/restund.yml
@@ -66,14 +66,15 @@
     owner: root
     group: root
   notify:
-    - systemctl daemon-reload
     # - restart restund # NOTE: Restarting restund should be done _manually_
     - rkt gc
     - rkt image gc
   tags:
     - restund
 
-- service:
+- name: Enable and start restund
+  systemd:
+    daemon_reload: true
     name:    restund
-    enabled: true
     state:   started
+    enabled: true

--- a/templates/nginx-default.conf.j2
+++ b/templates/nginx-default.conf.j2
@@ -3,6 +3,6 @@ server {
     server_name localhost;
 
     location /.well-known {
-        alias /var/www/html/.well-known;
+        alias {{ certbot_webroot_directory }}/.well-known;
     }
 }

--- a/templates/nginx-metrics.conf.j2
+++ b/templates/nginx-metrics.conf.j2
@@ -1,4 +1,4 @@
-{% if restund_enable_monitoring %}
+{% if restund_metrics_enabled %}
 server {
     listen {{ restund_metrics_listen_port }} ssl;
     server_name {{ certbot_domain }};
@@ -15,7 +15,7 @@ server {
     ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
     ssl_prefer_server_ciphers off;
 
-    {% if restund_enable_monitoring_client_certificates %}
+    {% if restund_metrics_client_certificates_enabled %}
     ssl_client_certificate /etc/nginx/ssl/certs/ca.crt;
     ssl_verify_client      on;
     {% endif %}

--- a/templates/nginx-metrics.conf.j2
+++ b/templates/nginx-metrics.conf.j2
@@ -36,4 +36,6 @@ server {
     }
 
 }
+{% else % }
+# restund_metrics_enabled is set to false, metrics will not be exposed.
 {% endif %}

--- a/templates/nginx-metrics.conf.j2
+++ b/templates/nginx-metrics.conf.j2
@@ -8,7 +8,7 @@ server {
 
     # intermediate configuration as per https://ssl-config.mozilla.org/#server=nginx
     ssl_session_timeout 1d;
-    ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions
+    ssl_session_cache shared:MetricsSSL:10m;  # about 40000 sessions
     ssl_session_tickets off;
 
     ssl_protocols TLSv1.2 TLSv1.3;

--- a/templates/nginx-metrics.conf.j2
+++ b/templates/nginx-metrics.conf.j2
@@ -1,0 +1,39 @@
+{% if restund_enable_monitoring %}
+server {
+    listen {{ restund_metrics_listen_port }} ssl;
+    server_name {{ certbot_domain }};
+
+    ssl_certificate /etc/letsencrypt/live/{{ certbot_domain }}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/{{ certbot_domain }}/privkey.pem;
+
+    # intermediate configuration as per https://ssl-config.mozilla.org/#server=nginx
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions
+    ssl_session_tickets off;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+
+    {% if restund_enable_monitoring_client_certificates %}
+    ssl_client_certificate /etc/nginx/ssl/certs/ca.crt;
+    ssl_verify_client      on;
+    {% endif %}
+
+    location /metrics/node {
+        proxy_pass http://127.0.0.1:9100/metrics;
+        proxy_http_version 1.1;
+    }
+
+    location /metrics/restund {
+        proxy_pass http://127.0.0.1:9200/metrics;
+        proxy_http_version 1.1;
+    }
+
+    location /metrics/process {
+        proxy_pass http://127.0.0.1:9256/metrics;
+        proxy_http_version 1.1;
+    }
+
+}
+{% endif %}


### PR DESCRIPTION
This PR only adds support for metrics exporters at the nginx level. It doesn't actually install those exporters (yet). Two FUTUREWORK comments will be dealt with in future PRs.

This PR is part of solving https://github.com/zinfra/backend-issues/issues/1013