### PR TITLE
Up until now, nginx did not get reloaded after a successful renewal.

### DIFF
--- a/tasks/certbot_nginx.yml
+++ b/tasks/certbot_nginx.yml
@@ -110,6 +110,11 @@
     path: "/etc/letsencrypt/live/{{ certbot_domain }}/fullchain.pem"
   register: cert_file
 
+- name: configure certbot
+  template:
+    src: 'certbot.ini.j2'
+    dest: "/etc/letsencrypt/cli.ini"
+
 - name: create certificates with cerbot/letsencrypt (this also installs a renewal cron job)
   shell: 'certbot certonly --webroot --webroot-path {{ certbot_webroot_directory }} -n --agree-tos --email {{ certbot_admin_email }} -d {{ certbot_domain }}'
   when: not cert_file.stat.exists

--- a/templates/certbot.ini.j2
+++ b/templates/certbot.ini.j2
@@ -1,0 +1,6 @@
+# Because we are using logrotate for greater flexibility, disable the
+# internal certbot logrotation.
+max-log-backups = 0
+
+[renewalparams]
+post-hook = systemctl reload nginx


### PR DESCRIPTION
This change set aims to address this by providing and managing the
certbot CLI configuration in which such hook is defined.

Fixes: https://github.com/zinfra/backend-issues/issues/1858