### PR TITLE
[firewall] Allow incoming TLS traffic also if certbot is enabled

### DIFF
--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -40,7 +40,7 @@
         restund_http_status_port | string,
         restund_metrics_listen_port | string
       ]
-      + ([ restund_tls_listen_port ] if restund_tls_certificate is defined else [])
+      + ([ restund_tls_listen_port ] if (restund_tls_certificate is defined or certbot_enabled) else [])
       + ([ local_port_range_list.stdout_lines | join(':') ] if local_port_range_list | length > 0 else [])
     }}
 


### PR DESCRIPTION
This condition should have been there right from the beginning. We missed it.