### PR TITLE
Firewall hardening

### DIFF
--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -36,8 +36,7 @@
       [
         '22',
         '80',
-        restund_tcp_listen_port | string,
-        restund_http_status_port | string,
+        restund_tcp_listen_port | string
       ]
       + ([ restund_metrics_listen_port ] if restund_metrics_enabled else [])
       + ([ restund_tls_listen_port ] if (restund_tls_certificate is defined or certbot_enabled) else [])
@@ -54,8 +53,7 @@
   loop: >-
     {{
       [
-        restund_udp_listen_port | string,
-        restund_udp_status_port | string
+        restund_udp_listen_port | string
       ]
       + ([ local_port_range_list.stdout_lines | join(':') ] if local_port_range_list | length > 0 else [])
       + ([ local_port_range_list.stdout_lines | join(':') ] if local_port_range_list | length > 0 else [])

--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -35,9 +35,9 @@
     {{
       [
         '22',
-        '80',
         restund_tcp_listen_port | string
       ]
+      + ([ '80' ] if certbot_enabled else [])
       + ([ restund_metrics_listen_port ] if restund_metrics_enabled else [])
       + ([ restund_tls_listen_port ] if (restund_tls_certificate is defined or certbot_enabled) else [])
       + ([ local_port_range_list.stdout_lines | join(':') ] if local_port_range_list | length > 0 else [])

--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -38,8 +38,8 @@
         '80',
         restund_tcp_listen_port | string,
         restund_http_status_port | string,
-        restund_metrics_listen_port | string
       ]
+      + ([ restund_metrics_listen_port ] if restund_metrics_enabled else [])
       + ([ restund_tls_listen_port ] if (restund_tls_certificate is defined or certbot_enabled) else [])
       + ([ local_port_range_list.stdout_lines | join(':') ] if local_port_range_list | length > 0 else [])
     }}


### PR DESCRIPTION
# What's new in this PR?

### Issues

Depending on certain feature flags, some ports are not required to be open. And, some were simply overlooked by myself during initial firewall configuration development, and should have never be opened (e.g. status ports). Please refer to the commit messages for further reasoning.

### Causes (Optional)

unnecessarily open ports in firewall

### Solutions

Only open ports on certain conditions

### Dependencies (Optional)

none

Needs releases with:

none

### Testing

developed and tested during an actual rollout
