### PR TITLE
Fix wrong certificate path in restund.conf

### DIFF
--- a/templates/restund.conf.j2
+++ b/templates/restund.conf.j2
@@ -7,7 +7,7 @@ udp_listen              {{ hostvars[inventory_hostname]['ansible_' + restund_net
 udp_sockbuf_size        524288
 tcp_listen              {{ hostvars[inventory_hostname]['ansible_' + restund_network_interface].ipv4.address }}:{{ restund_tcp_listen_port }}
 {% if restund_tls_certificate is defined %}
-tls_listen              {{ hostvars[inventory_hostname]['ansible_' + restund_network_interface].ipv4.address }}:{{ restund_tls_listen_port }},/usr/local/etc/restund/restund.pem
+tls_listen              {{ hostvars[inventory_hostname]['ansible_' + restund_network_interface].ipv4.address }}:{{ restund_tls_listen_port }},/etc/restund/restund.pem
 {% endif %}
 
 # modules


### PR DESCRIPTION
# What's new in this PR?

It appears that Restund is on its way onto K8s, so, I don't know what level of relevance this fix still has.

### Issues

The task *install restund tls certificate* puts the certificate in a non-configurable path: `/etc/restund/restund.pem`. That path is mounted 1:1 into the container. But since the Restund configuration points to a non-existing PEM file path, the process fails with during startup:

> Can't read certificate file /usr/local/etc/restunf/restund.pem

### Solutions

This change set adjusts the path in the Restund configuration file to match the path used in the task creating the PEM file.

### Testing

Tested during an actual rollout in order to fix things.
